### PR TITLE
Correção do seletor class

### DIFF
--- a/docs/selector.md
+++ b/docs/selector.md
@@ -19,7 +19,7 @@ Exemplo: http://jsfiddle.net/renanmpimentel/0a2oo703/
 jQuery('.nome-class');
 
 //Javascript puro
-document.getElementsByClassName('.nome-class');     
+document.getElementsByClassName('nome-class');     
 
 document.querySelectorAll('.nome-class');
 ```


### PR DESCRIPTION
Removido '.' do seletor de classe, JS puro.

Lembrete: verificar suporte à função querySelectorAll
http://caniuse.com/#feat=queryselector
